### PR TITLE
Corrección ejercicio c7.02

### DIFF
--- a/no_me_salen/cinematica/c7fis_02.html
+++ b/no_me_salen/cinematica/c7fis_02.html
@@ -114,7 +114,7 @@
 <tr>
   <td height="49" align="left" valign="middle" class="bodytext"><p> La velocidad con la que llega al piso, para los que viajan en el avión será:</p>
     <blockquote>
-      <p><em><strong><strong>v</strong><sub>yP </sub><strong>= </strong> <em>−</em> 5 <strong> </strong><span class="Estilo4">m</span></strong><span class="Estilo7">/</span><strong><span class="Estilo4">s</span>&sup2; </strong><strong>12,6 <strong> </strong></strong><strong><span class="Estilo4">s</span></strong></em></p>
+      <p><em><strong><strong>v</strong><sub>yP </sub><strong>= </strong> <em>−</em> 10 <strong> </strong><span class="Estilo4">m</span></strong><span class="Estilo7">/</span><strong><span class="Estilo4">s</span>&sup2; </strong><strong>12,6 <strong> </strong></strong><strong><span class="Estilo4">s</span></strong></em></p>
     </blockquote></td>
   <td valign="middle" class="bodytext">&nbsp;</td>
   <td valign="middle" class="bodytext">&nbsp;</td>


### PR DESCRIPTION
En la cuenta de la velocidad con la que llega al piso el móvil desde el punto de vista del avión, la aceleración debería ser: -10m/s^2. El resultado, de hecho, está tomando en cuenta esta aceleración.